### PR TITLE
Support the "missing value test" operator

### DIFF
--- a/src/ParamsParser.ts
+++ b/src/ParamsParser.ts
@@ -267,7 +267,11 @@ export class ParamsParser extends AbstractTokenizer {
       return left;
     }
 
-    if (biop === Operators.PLUS_PLUS || biop === Operators.MINUS_MINUS) {
+    if (
+      biop === Operators.PLUS_PLUS ||
+      biop === Operators.MINUS_MINUS ||
+      biop === Operators.EXISTS
+    ) {
       return createUnaryExpression(biop, left, false);
     }
 

--- a/src/ParamsParser.ts
+++ b/src/ParamsParser.ts
@@ -258,21 +258,23 @@ export class ParamsParser extends AbstractTokenizer {
     let i;
 
     // First, try to get the leftmost thing
-    // Then, check to see if there's a binary operator operating on that leftmost thing
+    // Then, get the operator following the leftmost thing
     left = this.parseToken();
     biop = this.parseBinaryOp();
 
-    // If there wasn't a binary operator, just return the leftmost node
-    if (!biop) {
-      return left;
-    }
-
+    // If the operator is a unary operator, create a unary expression with the leftmost thing
     if (
       biop === Operators.PLUS_PLUS ||
       biop === Operators.MINUS_MINUS ||
       biop === Operators.EXISTS
     ) {
-      return createUnaryExpression(biop, left, false);
+      left = createUnaryExpression(biop, left, false);
+      biop = this.parseBinaryOp();
+    }
+
+    // If there wasn't a binary operator, just return the leftmost node
+    if (!biop) {
+      return left;
     }
 
     // Otherwise, we need to start a stack to properly place the binary operations in their

--- a/src/enum/Operators.ts
+++ b/src/enum/Operators.ts
@@ -69,6 +69,7 @@ export const UnaryOps: Record<string, boolean> = {
   [Operators.PLUS]: true,
   [Operators.MINUS_MINUS]: true,
   [Operators.PLUS_PLUS]: true,
+  [Operators.EXISTS]: true,
 };
 
 /**
@@ -84,6 +85,7 @@ export const BinaryOps: Record<string, number> = {
   [Operators.MOD_EQUALS]: 0,
   [Operators.PLUS_PLUS]: 0,
   [Operators.MINUS_MINUS]: 0,
+  [Operators.EXISTS]: 0,
 
   // Logical OR
   [Operators.OR]: 1,

--- a/test/__snapshots__/parser-valid.spec.ts.snap
+++ b/test/__snapshots__/parser-valid.spec.ts.snap
@@ -10865,82 +10865,34 @@ Array [
 exports[`exists.ftl should have correct ast 1`] = `
 ProgramNode {
   "body": Array [
-    AssignNode {
-      "end": 15,
+    ConditionNode {
+      "consequent": Array [
+        TextNode {
+          "end": 13,
+          "loc": Object {
+            "end": Object {
+              "column": 14,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 10,
+              "line": 1,
+            },
+          },
+          "start": 9,
+          "text": "good",
+          "type": "Text",
+        },
+      ],
+      "end": 9,
       "loc": Object {
         "end": Object {
-          "column": 16,
+          "column": 10,
           "line": 1,
         },
         "start": Object {
           "column": 1,
           "line": 1,
-        },
-      },
-      "params": Array [
-        Object {
-          "left": Object {
-            "name": "x",
-            "type": "Identifier",
-          },
-          "operator": "=",
-          "right": Object {
-            "raw": "1",
-            "type": "Literal",
-            "value": 1,
-          },
-          "type": "AssignmentExpression",
-        },
-      ],
-      "start": 0,
-      "type": "Assign",
-    },
-    TextNode {
-      "end": 19,
-      "loc": Object {
-        "end": Object {
-          "column": 3,
-          "line": 3,
-        },
-        "start": Object {
-          "column": 16,
-          "line": 1,
-        },
-      },
-      "start": 15,
-      "text": "
-
-- ",
-      "type": "Text",
-    },
-    ConditionNode {
-      "consequent": Array [
-        TextNode {
-          "end": 32,
-          "loc": Object {
-            "end": Object {
-              "column": 16,
-              "line": 3,
-            },
-            "start": Object {
-              "column": 12,
-              "line": 3,
-            },
-          },
-          "start": 28,
-          "text": "good",
-          "type": "Text",
-        },
-      ],
-      "end": 28,
-      "loc": Object {
-        "end": Object {
-          "column": 12,
-          "line": 3,
-        },
-        "start": Object {
-          "column": 3,
-          "line": 3,
         },
       },
       "params": Object {
@@ -10952,15 +10904,82 @@ ProgramNode {
         "prefix": false,
         "type": "UnaryExpression",
       },
+      "start": 0,
+      "type": "Condition",
+    },
+    TextNode {
+      "end": 20,
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 20,
+          "line": 1,
+        },
+      },
       "start": 19,
+      "text": "
+",
+      "type": "Text",
+    },
+    ConditionNode {
+      "consequent": Array [
+        TextNode {
+          "end": 38,
+          "loc": Object {
+            "end": Object {
+              "column": 19,
+              "line": 2,
+            },
+            "start": Object {
+              "column": 15,
+              "line": 2,
+            },
+          },
+          "start": 34,
+          "text": "good",
+          "type": "Text",
+        },
+      ],
+      "end": 34,
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "params": Object {
+        "left": Object {
+          "argument": Object {
+            "name": "x",
+            "type": "Identifier",
+          },
+          "operator": "??",
+          "prefix": false,
+          "type": "UnaryExpression",
+        },
+        "operator": "&&",
+        "right": Object {
+          "name": "y",
+          "type": "Identifier",
+        },
+        "type": "LogicalExpression",
+      },
+      "start": 20,
       "type": "Condition",
     },
   ],
-  "end": 37,
+  "end": 43,
   "loc": Object {
     "end": Object {
-      "column": 21,
-      "line": 3,
+      "column": 24,
+      "line": 2,
     },
     "start": Object {
       "column": 1,
@@ -10975,48 +10994,65 @@ ProgramNode {
 exports[`exists.ftl should have correct tokens 1`] = `
 Array [
   Object {
-    "end": 15,
-    "endTag": ">",
-    "params": "x = 1",
-    "start": 0,
-    "startTag": "<#",
-    "text": "assign",
-    "type": "OpenDirective",
-  },
-  Object {
-    "end": 19,
-    "endTag": undefined,
-    "params": undefined,
-    "start": 15,
-    "startTag": undefined,
-    "text": "
-
-- ",
-    "type": "Text",
-  },
-  Object {
-    "end": 28,
+    "end": 9,
     "endTag": ">",
     "params": "x??",
-    "start": 19,
+    "start": 0,
     "startTag": "<#",
     "text": "if",
     "type": "OpenDirective",
   },
   Object {
-    "end": 32,
+    "end": 13,
     "endTag": undefined,
     "params": undefined,
-    "start": 28,
+    "start": 9,
     "startTag": undefined,
     "text": "good",
     "type": "Text",
   },
   Object {
-    "end": 38,
+    "end": 19,
     "endTag": ">",
     "params": undefined,
-    "start": 32,
+    "start": 13,
+    "startTag": "</#",
+    "text": "if",
+    "type": "CloseDirective",
+  },
+  Object {
+    "end": 20,
+    "endTag": undefined,
+    "params": undefined,
+    "start": 19,
+    "startTag": undefined,
+    "text": "
+",
+    "type": "Text",
+  },
+  Object {
+    "end": 34,
+    "endTag": ">",
+    "params": "x?? && y",
+    "start": 20,
+    "startTag": "<#",
+    "text": "if",
+    "type": "OpenDirective",
+  },
+  Object {
+    "end": 38,
+    "endTag": undefined,
+    "params": undefined,
+    "start": 34,
+    "startTag": undefined,
+    "text": "good",
+    "type": "Text",
+  },
+  Object {
+    "end": 44,
+    "endTag": ">",
+    "params": undefined,
+    "start": 38,
     "startTag": "</#",
     "text": "if",
     "type": "CloseDirective",

--- a/test/__snapshots__/parser-valid.spec.ts.snap
+++ b/test/__snapshots__/parser-valid.spec.ts.snap
@@ -10862,6 +10862,168 @@ Array [
 ]
 `;
 
+exports[`exists.ftl should have correct ast 1`] = `
+ProgramNode {
+  "body": Array [
+    AssignNode {
+      "end": 15,
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "params": Array [
+        Object {
+          "left": Object {
+            "name": "x",
+            "type": "Identifier",
+          },
+          "operator": "=",
+          "right": Object {
+            "raw": "1",
+            "type": "Literal",
+            "value": 1,
+          },
+          "type": "AssignmentExpression",
+        },
+      ],
+      "start": 0,
+      "type": "Assign",
+    },
+    TextNode {
+      "end": 19,
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "start": 15,
+      "text": "
+
+- ",
+      "type": "Text",
+    },
+    ConditionNode {
+      "consequent": Array [
+        TextNode {
+          "end": 32,
+          "loc": Object {
+            "end": Object {
+              "column": 16,
+              "line": 3,
+            },
+            "start": Object {
+              "column": 12,
+              "line": 3,
+            },
+          },
+          "start": 28,
+          "text": "good",
+          "type": "Text",
+        },
+      ],
+      "end": 28,
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "params": Object {
+        "argument": Object {
+          "name": "x",
+          "type": "Identifier",
+        },
+        "operator": "??",
+        "prefix": false,
+        "type": "UnaryExpression",
+      },
+      "start": 19,
+      "type": "Condition",
+    },
+  ],
+  "end": 37,
+  "loc": Object {
+    "end": Object {
+      "column": 21,
+      "line": 3,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+    },
+  },
+  "start": 0,
+  "type": "Program",
+}
+`;
+
+exports[`exists.ftl should have correct tokens 1`] = `
+Array [
+  Object {
+    "end": 15,
+    "endTag": ">",
+    "params": "x = 1",
+    "start": 0,
+    "startTag": "<#",
+    "text": "assign",
+    "type": "OpenDirective",
+  },
+  Object {
+    "end": 19,
+    "endTag": undefined,
+    "params": undefined,
+    "start": 15,
+    "startTag": undefined,
+    "text": "
+
+- ",
+    "type": "Text",
+  },
+  Object {
+    "end": 28,
+    "endTag": ">",
+    "params": "x??",
+    "start": 19,
+    "startTag": "<#",
+    "text": "if",
+    "type": "OpenDirective",
+  },
+  Object {
+    "end": 32,
+    "endTag": undefined,
+    "params": undefined,
+    "start": 28,
+    "startTag": undefined,
+    "text": "good",
+    "type": "Text",
+  },
+  Object {
+    "end": 38,
+    "endTag": ">",
+    "params": undefined,
+    "start": 32,
+    "startTag": "</#",
+    "text": "if",
+    "type": "CloseDirective",
+  },
+]
+`;
+
 exports[`expresion.ftl should have correct ast 1`] = `
 ProgramNode {
   "body": Array [

--- a/test/resource/valid/exists.ftl
+++ b/test/resource/valid/exists.ftl
@@ -1,3 +1,2 @@
-<#assign x = 1>
-
-- <#if x??>good</#if>
+<#if x??>good</#if>
+<#if x?? && y>good</#if>

--- a/test/resource/valid/exists.ftl
+++ b/test/resource/valid/exists.ftl
@@ -1,0 +1,3 @@
+<#assign x = 1>
+
+- <#if x??>good</#if>


### PR DESCRIPTION
This adds support for `expression??` to check for existence: https://freemarker.apache.org/docs/dgui_template_exp.html#dgui_template_exp_missing_test 

It looks like the `??` operator was already defined, but operator precedence wasn't working correctly. I'm not sure if this is a good solution or not, but it does seem to work! It's my first time using freemarker, and also this project, so I'm just guessing here.

Edit: I also noticed that binary expressions containing unary expressions weren't parsing correctly, and included a fix. Although I only tested with the unary expressions `++`, `--`, and `??`, so I'm not sure if others work correctly.